### PR TITLE
Added gitignore and upgraded glob and tape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "require a whole directory of trees in bulk",
   "main": "index.js",
   "dependencies": {
-    "glob": "~3.2.7"
+    "glob": "~7.1.1"
   },
   "devDependencies": {
-    "tape": "^2.13.2"
+    "tape": "^4.6.2"
   },
   "scripts": {
     "test": "tape test/*.js"


### PR DESCRIPTION
Added gitignore and updated npm packages

`glob` ("~7.1.1") now has no more deprecation notices.

Updated tape to "^4.6.2".

Supersedes #4.
